### PR TITLE
Switch sd9.png and sd10.png

### DIFF
--- a/layouts/partials/scientific-domains.html
+++ b/layouts/partials/scientific-domains.html
@@ -73,8 +73,8 @@
             <td class="bold-text">Interactive Computing</td>
         </tr>
         <tr>
-            <td><img class="cell-layout" src="images/content_images/sc_dom_img/sd10.png" alt="Many dots connected by lines."></td>
             <td><img class="cell-layout" src="images/content_images/sc_dom_img/sd9.png" alt="A strand of DNA."></td>
+            <td><img class="cell-layout" src="images/content_images/sc_dom_img/sd10.png" alt="Many dots connected by lines."></td>
             <td><img class="cell-layout" src="images/content_images/sc_dom_img/sd11.png" alt="Four mathematical symbols."></td>
             <td><img class="cell-layout" src="images/content_images/sc_dom_img/sd12.png" alt="A three-dimensional graph with a box."></td>
             <td><img class="cell-layout" src="images/content_images/sc_dom_img/sd13.png" alt="A conical flask and test tube."></td>


### PR DESCRIPTION
Switching the images sd9.png and sd10.png to correctly illustrate the presented scientific domains.